### PR TITLE
feat: Update React frontend to integrate with existing Next.js proxy …

### DIFF
--- a/stock-streaming-frontend/.env
+++ b/stock-streaming-frontend/.env
@@ -1,2 +1,2 @@
-REACT_APP_PROXY_URL=http://localhost:3001
+REACT_APP_PROXY_URL=http://localhost:3000
 GENERATE_SOURCEMAP=false

--- a/stock-streaming-frontend/README.md
+++ b/stock-streaming-frontend/README.md
@@ -1,27 +1,29 @@
 # 📈 실시간 주식 모니터
 
-React와 WebSocket을 사용한 실시간 주식 데이터 스트리밍 애플리케이션입니다.
+React와 SSE(Server-Sent Events)를 사용한 실시간 주식 데이터 스트리밍 애플리케이션입니다.
 
 ## 🚀 기능
 
-- **실시간 데이터 스트리밍**: WebSocket을 통한 HotStreaming 방식으로 주식 데이터 실시간 업데이트
+- **실시간 데이터 스트리밍**: SSE를 통한 HotStreaming 방식으로 주식 데이터 실시간 업데이트
 - **주식 선택**: 삼성전자, LG전자, SK하이닉스 중 원하는 주식 선택
 - **아름다운 UI**: 모던하고 직관적인 사용자 인터페이스
 - **연결 상태 표시**: 프록시 서버 연결 상태 실시간 모니터링
 - **반응형 디자인**: 다양한 화면 크기에 최적화
+- **디버그 패널**: SSE 연결 상태 및 데이터 수신 모니터링
 
 ## 🛠 기술 스택
 
 - **React 18** + TypeScript
-- **Socket.IO Client** - WebSocket 통신
+- **Server-Sent Events (SSE)** - 실시간 스트리밍
 - **Styled Components** - CSS-in-JS 스타일링
-- **Recharts** - 차트 라이브러리 (확장 가능)
+- **Next.js Proxy Server** - CORS 및 API 프록시
 
 ## 📦 설치 및 실행
 
 ### 필수 조건
 - Node.js 16+ 
 - npm 또는 yarn
+- Next.js 프록시 서버 (포트 3000)
 
 ### 설치
 ```bash
@@ -32,7 +34,7 @@ npm install
 ### 환경 설정
 `.env` 파일에서 프록시 서버 URL을 설정하세요:
 ```
-REACT_APP_PROXY_URL=http://localhost:3001
+REACT_APP_PROXY_URL=http://localhost:3000
 ```
 
 ### 실행
@@ -40,23 +42,32 @@ REACT_APP_PROXY_URL=http://localhost:3001
 npm start
 ```
 
-브라우저에서 [http://localhost:3000](http://localhost:3000)으로 접속하세요.
+브라우저에서 [http://localhost:3001](http://localhost:3001)으로 접속하세요.
+(React 앱은 3001 포트, Next.js 프록시는 3000 포트)
 
 ## 🔌 프록시 서버 연동
 
-이 애플리케이션은 별도의 프록시 서버와 연동하여 동작합니다. 프록시 서버는 다음 이벤트를 지원해야 합니다:
+이 애플리케이션은 Next.js 프록시 서버와 연동하여 동작합니다.
 
-### 클라이언트에서 서버로
-- `subscribe`: 특정 주식 구독
-- `unsubscribe`: 특정 주식 구독 해제
+### 프록시 서버 실행
+```bash
+cd cors-proxy-servers/nextjs-proxy
+npm install
+npm run dev
+```
 
-### 서버에서 클라이언트로
-- `stockData`: 주식 데이터 전송
+### API 엔드포인트
+- **GET /api/stocks?name={stockName}**: SSE 스트림으로 주식 데이터 수신
+
+### 지원하는 주식 이름
+- `Samsung Electronics` (삼성전자)
+- `LG Electronics` (LG전자)  
+- `SK Hynix` (SK하이닉스)
 
 ### 데이터 형식
 ```typescript
 interface StockData {
-  symbol: string;      // 주식 심볼 (SAMSUNG, LG, SK)
+  symbol: string;      // 주식 심볼
   name: string;        // 주식 이름
   price: number;       // 현재 가격
   change: number;      // 변동 금액
@@ -68,9 +79,12 @@ interface StockData {
 
 ## 📱 사용 방법
 
-1. **주식 선택**: 상단의 체크박스에서 모니터링할 주식을 선택하세요
-2. **연결 확인**: 프록시 서버 연결 상태를 확인하세요
-3. **실시간 모니터링**: 선택한 주식들의 실시간 데이터를 확인하세요
+1. **프록시 서버 실행**: Next.js 프록시 서버를 먼저 실행하세요
+2. **React 앱 실행**: React 개발 서버를 실행하세요
+3. **주식 선택**: 상단의 체크박스에서 모니터링할 주식을 선택하세요
+4. **연결 확인**: 프록시 서버 연결 상태를 확인하세요
+5. **실시간 모니터링**: 선택한 주식들의 실시간 데이터를 확인하세요
+6. **디버그**: 문제가 있다면 디버그 패널을 열어 연결 상태를 확인하세요
 
 ## 🎨 UI 특징
 
@@ -78,6 +92,7 @@ interface StockData {
 - **색상 코딩**: 각 주식별 고유 색상으로 구분
 - **변동 표시**: 상승/하락에 따른 색상과 화살표 표시
 - **부드러운 애니메이션**: 호버 효과와 펄스 애니메이션
+- **디버그 패널**: SSE 연결 및 데이터 수신 상태 모니터링
 
 ## 📂 프로젝트 구조
 
@@ -86,9 +101,10 @@ src/
 ├── components/          # React 컴포넌트
 │   ├── StockSelector.tsx    # 주식 선택 UI
 │   ├── StockCard.tsx        # 주식 데이터 카드
-│   └── ConnectionStatus.tsx # 연결 상태 표시
+│   ├── ConnectionStatus.tsx # 연결 상태 표시
+│   └── DebugPanel.tsx       # 디버그 패널
 ├── hooks/              # 커스텀 훅
-│   └── useStockStream.ts    # WebSocket 스트리밍 훅
+│   └── useStockStream.ts    # SSE 스트리밍 훅
 ├── types/              # TypeScript 타입 정의
 │   └── stock.ts            # 주식 관련 타입
 └── App.tsx             # 메인 애플리케이션
@@ -98,13 +114,30 @@ src/
 
 ### 추가 기능 구현시
 1. `src/types/stock.ts`에서 데이터 타입 확장
-2. `src/hooks/useStockStream.ts`에서 WebSocket 로직 수정
+2. `src/hooks/useStockStream.ts`에서 SSE 로직 수정
 3. 새로운 컴포넌트는 `src/components/`에 추가
 
 ### 스타일링
 - Styled Components를 사용하여 CSS-in-JS 방식으로 스타일링
 - 반응형 디자인 고려
 - 일관된 색상 팔레트 유지
+
+### SSE 연결 디버깅
+- 브라우저 개발자 도구의 Network 탭에서 SSE 연결 상태 확인
+- Console 탭에서 SSE 이벤트 로그 확인
+- 앱 내 디버그 패널을 통한 실시간 상태 모니터링
+
+## 🚨 문제 해결
+
+### 연결 문제
+1. Next.js 프록시 서버가 3000 포트에서 실행 중인지 확인
+2. Spring Boot 백엔드 서버가 8080 포트에서 실행 중인지 확인
+3. 브라우저 개발자 도구에서 CORS 오류 확인
+
+### 데이터 수신 문제
+1. 디버그 패널에서 SSE 연결 상태 확인
+2. 브라우저 Console에서 SSE 이벤트 로그 확인
+3. 주식 이름 매개변수가 정확한지 확인
 
 ## 🤝 기여
 

--- a/stock-streaming-frontend/package-lock.json
+++ b/stock-streaming-frontend/package-lock.json
@@ -20,7 +20,6 @@
         "react-dom": "^19.1.1",
         "react-scripts": "5.0.1",
         "recharts": "^3.1.0",
-        "socket.io-client": "^4.8.1",
         "styled-components": "^6.1.19",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -3257,12 +3256,6 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
-    },
-    "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
@@ -7260,66 +7253,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/engine.io-client": {
-      "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
-      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1",
-        "engine.io-parser": "~5.2.1",
-        "ws": "~8.17.1",
-        "xmlhttprequest-ssl": "~2.1.1"
-      }
-    },
-    "node_modules/engine.io-client/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/engine.io-parser": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -15567,68 +15500,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/socket.io-client": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
-      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.2",
-        "engine.io-client": "~6.6.1",
-        "socket.io-parser": "~4.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io-client/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socket.io-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
-      "license": "MIT",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io-parser/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
@@ -18198,14 +18069,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
-    },
-    "node_modules/xmlhttprequest-ssl": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
-      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/stock-streaming-frontend/package.json
+++ b/stock-streaming-frontend/package.json
@@ -15,7 +15,6 @@
     "react-dom": "^19.1.1",
     "react-scripts": "5.0.1",
     "recharts": "^3.1.0",
-    "socket.io-client": "^4.8.1",
     "styled-components": "^6.1.19",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
@@ -44,7 +43,7 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:3001",
+  "proxy": "http://localhost:3000",
   "devDependencies": {
     "@types/styled-components": "^5.1.34"
   }

--- a/stock-streaming-frontend/src/App.tsx
+++ b/stock-streaming-frontend/src/App.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { StockSelector } from './components/StockSelector';
 import { StockCard } from './components/StockCard';
 import { ConnectionStatus } from './components/ConnectionStatus';
+import { DebugPanel } from './components/DebugPanel';
 import { useStockStream } from './hooks/useStockStream';
 import './App.css';
 
@@ -75,7 +76,7 @@ function App() {
   
   const { stockData, isConnected, error } = useStockStream({
     selectedStocks,
-    proxyServerUrl: process.env.REACT_APP_PROXY_URL || 'http://localhost:3001'
+    proxyServerUrl: process.env.REACT_APP_PROXY_URL || 'http://localhost:3000'
   });
 
   const handleStockToggle = (symbol: string) => {
@@ -107,6 +108,12 @@ function App() {
             error={error}
           />
         )}
+
+        <DebugPanel
+          stockData={stockData}
+          isConnected={isConnected}
+          error={error}
+        />
 
         {stockDataArray.length > 0 ? (
           <StockGrid>

--- a/stock-streaming-frontend/src/components/DebugPanel.tsx
+++ b/stock-streaming-frontend/src/components/DebugPanel.tsx
@@ -1,0 +1,150 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+interface DebugPanelProps {
+  stockData: Record<string, any>;
+  isConnected: boolean;
+  error: string | null;
+}
+
+const DebugContainer = styled.div`
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 8px;
+  padding: 16px;
+  margin: 16px 0;
+  font-family: monospace;
+  font-size: 12px;
+`;
+
+const DebugTitle = styled.h4`
+  margin: 0 0 12px 0;
+  color: #495057;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const DebugContent = styled.div<{ isOpen: boolean }>`
+  display: ${props => props.isOpen ? 'block' : 'none'};
+  max-height: 300px;
+  overflow-y: auto;
+  background: white;
+  padding: 8px;
+  border-radius: 4px;
+  border: 1px solid #e9ecef;
+`;
+
+const StatusBadge = styled.span<{ status: 'connected' | 'disconnected' | 'error' }>`
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 500;
+  color: white;
+  background: ${props => 
+    props.status === 'connected' ? '#28a745' :
+    props.status === 'error' ? '#dc3545' : '#6c757d'
+  };
+`;
+
+const TestButton = styled.button`
+  padding: 4px 8px;
+  margin: 4px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+  font-size: 10px;
+  
+  &:hover {
+    background: #f8f9fa;
+  }
+`;
+
+export const DebugPanel: React.FC<DebugPanelProps> = ({
+  stockData,
+  isConnected,
+  error
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const testSSEConnection = (stockName: string) => {
+    const eventSource = new EventSource(`http://localhost:3000/api/stocks?name=${encodeURIComponent(stockName)}`);
+    
+    eventSource.onopen = () => {
+      console.log(`Test: ${stockName} SSE 연결 성공`);
+    };
+    
+    eventSource.onmessage = (event) => {
+      console.log(`Test: ${stockName} 데이터:`, event.data);
+    };
+    
+    eventSource.onerror = (err) => {
+      console.error(`Test: ${stockName} SSE 오류:`, err);
+    };
+
+    setTimeout(() => {
+      eventSource.close();
+      console.log(`Test: ${stockName} 연결 종료`);
+    }, 10000);
+  };
+
+  const getStatus = () => {
+    if (error) return 'error';
+    if (isConnected) return 'connected';
+    return 'disconnected';
+  };
+
+  return (
+    <DebugContainer>
+      <DebugTitle onClick={() => setIsOpen(!isOpen)}>
+        🔧 디버그 패널 
+        <StatusBadge status={getStatus()}>
+          {isConnected ? 'Connected' : error ? 'Error' : 'Disconnected'}
+        </StatusBadge>
+        <span>{isOpen ? '▲' : '▼'}</span>
+      </DebugTitle>
+      
+      <DebugContent isOpen={isOpen}>
+        <div>
+          <strong>연결 상태:</strong> {isConnected ? '연결됨' : '연결 안됨'}
+        </div>
+        
+        {error && (
+          <div style={{ color: '#dc3545', margin: '8px 0' }}>
+            <strong>오류:</strong> {error}
+          </div>
+        )}
+        
+        <div style={{ margin: '8px 0' }}>
+          <strong>수신된 데이터:</strong>
+          <pre style={{ margin: '4px 0', fontSize: '10px' }}>
+            {JSON.stringify(stockData, null, 2)}
+          </pre>
+        </div>
+
+        <div style={{ margin: '8px 0' }}>
+          <strong>SSE 연결 테스트:</strong>
+          <div>
+            <TestButton onClick={() => testSSEConnection('Samsung Electronics')}>
+              삼성전자 테스트
+            </TestButton>
+            <TestButton onClick={() => testSSEConnection('LG Electronics')}>
+              LG전자 테스트
+            </TestButton>
+            <TestButton onClick={() => testSSEConnection('SK Hynix')}>
+              SK하이닉스 테스트
+            </TestButton>
+          </div>
+        </div>
+
+        <div style={{ fontSize: '10px', color: '#6c757d', marginTop: '8px' }}>
+          * 브라우저 개발자 도구 콘솔에서 상세 로그를 확인하세요.
+        </div>
+      </DebugContent>
+    </DebugContainer>
+  );
+};

--- a/stock-streaming-frontend/src/types/stock.ts
+++ b/stock-streaming-frontend/src/types/stock.ts
@@ -15,7 +15,7 @@ export interface StockConfig {
 }
 
 export const STOCK_CONFIGS: StockConfig[] = [
-  { symbol: 'SAMSUNG', name: '삼성전자', color: '#1f77b4' },
-  { symbol: 'LG', name: 'LG전자', color: '#ff7f0e' },
-  { symbol: 'SK', name: 'SK하이닉스', color: '#2ca02c' }
+  { symbol: 'Samsung Electronics', name: '삼성전자', color: '#1f77b4' },
+  { symbol: 'LG Electronics', name: 'LG전자', color: '#ff7f0e' },
+  { symbol: 'SK Hynix', name: 'SK하이닉스', color: '#2ca02c' }
 ];


### PR DESCRIPTION
…via SSE

- SSE(Server-Sent Events) 방식으로 WebSocket에서 변경
- 기존 Next.js 프록시 서버의 /api/stocks 엔드포인트와 연동
- 한국 주식 이름으로 변경: Samsung Electronics, LG Electronics, SK Hynix
- 디버그 패널 추가로 SSE 연결 상태 모니터링
- Socket.IO 의존성 제거 및 네이티브 EventSource API 사용
- 프록시 서버 포트를 3000으로 변경, React 앱은 3001 포트 사용

Integration Changes:
- Convert from WebSocket to Server-Sent Events (SSE)
- Connect with existing Next.js proxy at /api/stocks endpoint
- Update stock symbols for Korean market
- Add debug panel for connection monitoring
- Remove Socket.IO dependency
- Use native EventSource API for real-time streaming